### PR TITLE
Rwu/fix/namespace

### DIFF
--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/GeneratorHelpers.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/GeneratorHelpers.xtend
@@ -361,7 +361,12 @@ class GeneratorHelpers {
         package_impl = node.eContainer.eContainer as AmentPackageImpl;
         return package_impl;
     }
-
+    def static String removeLeadingSlash(String input) {
+        if (input !== null && input.startsWith("/")) {
+            return input.substring(1)
+    }
+        return input
+    }
     //Launch files generators
 //  def check_ns(ComponentInterface component){
 //      if (component.hasNS){

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/READMECompiler.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/READMECompiler.xtend
@@ -10,6 +10,7 @@ import system.impl.RosServiceClientReferenceImpl
 import system.impl.RosServiceServerReferenceImpl
 import system.impl.RosSubscriberReferenceImpl
 import com.google.inject.Inject
+import system.RosParameter
 
 class READMECompiler {
 
@@ -23,11 +24,13 @@ This package has be created automatically using the [RosTooling](https://github.
 
 It holds the launch file to run the following nodes:
 «FOR node:getRos2Nodes(system)»
-- «(node as RosNode).name»
+«IF !node.namespace.nullOrEmpty»- «GeneratorHelpers.removeLeadingSlash(node.namespace)»_«(node as RosNode).name»«ELSE»
+- «(node as RosNode).name»«ENDIF»
 «ENDFOR»
 «FOR subsystem:system.subsystems»
 «FOR node:getRos2Nodes(subsystem)»
-- «(node as RosNode).name»
+«IF !node.namespace.nullOrEmpty»- «GeneratorHelpers.removeLeadingSlash(node.namespace)»_«(node as RosNode).name»«ELSE»
+- «(node as RosNode).name»«ENDIF»
 «ENDFOR»
 «ENDFOR»
 
@@ -43,7 +46,7 @@ It holds the launch file to run the following nodes:
 ### Using release
 
 «IF system.fromFile.nullOrEmpty»
-This package can be copied to a valid ROS 2 workspace. To be sure that all the related dependencies are intalles the command **rosdep install** can be used.
+This package can be copied to a valid ROS 2 workspace. To be sure that all the related dependencies are installed and the command **rosdep install** can be used.
 Then the workspace must be compiled using the common ROS 2 build command:
 
 ```
@@ -85,7 +88,7 @@ source install/setup.bash
 To execute the launch file, the following command can be called:
 
 ```
-ros2 launch «system.name» «system.name».launch.py «FOR param:system.parameter»«param.name»:=«get_param_value(param.value,param.name)» «ENDFOR»
+ros2 launch «system.name» «system.name».launch.py «FOR param:system.parameter»«(param as RosParameter).name»:=«get_param_value((param as RosParameter).value,(param as RosParameter).name)» «ENDFOR»
 ```
 
 The generated launch files requires the xterm package, it can be installed by:
@@ -98,13 +101,13 @@ sudo apt install xterm
 To launch this system there is already an existing package that contains the launch file. It can be started by:
 
 ```
-ros2 launch «system.fromFile.split("/",2).get(0)» «system.fromFile.substring(system.fromFile.lastIndexOf('/') + 1)» «FOR param:system.parameter»«param.name»:=«get_param_value(param.value,param.name)» «ENDFOR»
+ros2 launch «system.fromFile.split("/",2).get(0)» «system.fromFile.substring(system.fromFile.lastIndexOf('/') + 1)» «FOR param:system.parameter»«(param as RosParameter).name»:=«get_param_value((param as RosParameter).value,(param as RosParameter).name)» «ENDFOR»
 ```
 «ENDIF»
 
 
      '''
-     
+
      def IsInterfacesEmpty(System system){
          for(node: getRos2Nodes(system)){
              if (!(node as RosNode).rosinterfaces.empty){
@@ -118,10 +121,10 @@ ros2 launch «system.fromFile.split("/",2).get(0)» «system.fromFile.substring(
              }
          }
          }
-         
+
          return true
      }
-     
+
      def getPortInfo(RosInterface port ){
          if(port.reference.eClass.toString.contains("RosPublisherReference") && (port.reference as RosPublisherReferenceImpl).basicGetFrom.message !== null){
              return "- Publisher: "+ port.name+" ["+(port.reference as RosPublisherReferenceImpl).basicGetFrom.message.fullname+"]"
@@ -144,5 +147,3 @@ ros2 launch «system.fromFile.split("/",2).get(0)» «system.fromFile.substring(
      }
 
     }
-    
-    

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/RosSystemGenerator.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/RosSystemGenerator.xtend
@@ -48,10 +48,19 @@ class RosSystemGenerator extends AbstractGenerator {
                     if(component.eClass.name == "RosNode"){
                         if(!(component as RosNode).rosparameters.nullOrEmpty){
                             yaml_gen=true
-                            fsa.generateFile(
+                            if ((component as RosNode).namespace !== null){
+                                fsa.generateFile(
+                                system.getName().toLowerCase+"/config/"+(component as RosNode).namespace+"_"+(component as RosNode).getName()+".yaml",
+                                compile_toROS2yaml(component as RosNode).toString().replace("\t","  ")
+                                )
+                            }
+                            else{
+                                fsa.generateFile(
                                 system.getName().toLowerCase+"/config/"+(component as RosNode).getName()+".yaml",
                                 compile_toROS2yaml(component as RosNode).toString().replace("\t","  ")
                             )
+                            }
+
                     }}
                 }
                 fsa.generateFile(
@@ -89,4 +98,3 @@ class RosSystemGenerator extends AbstractGenerator {
     }
 
 }
-

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/YamlFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/YamlFileCompiler_ROS2.xtend
@@ -2,18 +2,19 @@ package de.fraunhofer.ipa.rossystem.generator
 
 import com.google.inject.Inject
 import system.RosNode
+import system.RosParameter
 
 class YamlFileCompiler_ROS2 {
-    
+
     @Inject extension GeneratorHelpers
 
     def compile_toROS2yaml(RosNode component)'''
     «component.name»:
       ros__parameters:
         «FOR param:component.rosparameters»
-        «param.name»: «get_param_value(param.value,param.name)»
+        «param.from.name»: «get_param_value(param.value,param.name)»
         «ENDFOR»
-    
+
     '''
-    
+
 }


### PR DESCRIPTION
This pull request introduces improvements to the naming and handling of ROS 2 nodes and their parameters, especially in the context of namespaces, across the codebase. The main focus is to ensure that node names in launch files and documentation are unique and descriptive when namespaces are used, and to standardize parameter handling. The changes also add a helper function for string manipulation and address minor documentation and parameter reference issues.

**Launch file and node naming improvements:**

* Node variable names in generated launch files now include the namespace (with the leading slash removed) as a prefix when a namespace is present, ensuring uniqueness and clarity. This change is reflected in both the launch file compiler and the README documentation. [[1]](diffhunk://#diff-427ea82dad038cb96664b504e295cc629d9e7ab55b485f0017de103c6b66008bL64-L68) [[2]](diffhunk://#diff-427ea82dad038cb96664b504e295cc629d9e7ab55b485f0017de103c6b66008bR91-R104) [[3]](diffhunk://#diff-dcf6b971ffe13144b99cce3d75b2fa468d458ddfa935d65b86eec36bf81c786cL26-R33)
* The generated YAML configuration files are now named with the namespace as a prefix if the node has a namespace, improving organization and avoiding filename collisions.

**Parameter handling and references:**

* Parameter references in launch commands and documentation are now explicitly cast to `RosParameter`, ensuring type safety and consistency. [[1]](diffhunk://#diff-dcf6b971ffe13144b99cce3d75b2fa468d458ddfa935d65b86eec36bf81c786cR13) [[2]](diffhunk://#diff-dcf6b971ffe13144b99cce3d75b2fa468d458ddfa935d65b86eec36bf81c786cL88-R91) [[3]](diffhunk://#diff-dcf6b971ffe13144b99cce3d75b2fa468d458ddfa935d65b86eec36bf81c786cL101-R104)
* In YAML configuration generation, parameter names are now taken from the referenced source parameter (`param.from.name`) rather than the local name, which improves accuracy when parameters are shared or aliased.

**Utilities and minor fixes:**

* Added a `removeLeadingSlash` helper function to standardize namespace string formatting by removing a leading slash if present.
* Fixed a minor typo in the README instructions for installing dependencies.