### PR TITLE
Fixed source install

### DIFF
--- a/EclipseInstaller/ROSModel.setup
+++ b/EclipseInstaller/ROSModel.setup
@@ -62,9 +62,10 @@
         name="org.eclipse.sirius.specifier.feature.group"/>
     <requirement
         name="org.eclipse.cdt.feature.group"/>
-    <requirement name="org.eclipse.platform.ide"/>
-    <requirement
-        name="org.eclipse.m2e.feature.feature.group"/>
+      <requirement
+          name="org.eclipse.sdk.feature.group"/>
+      <requirement
+          name="org.eclipse.m2e.feature.feature.group"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -84,6 +85,7 @@
             url="https://download.eclipse.org/releases/2024-09"/>
         <repository 
             url="https://download.eclipse.org/eclipse/updates/4.33"/>
+        
       </repositoryList>
     </targlet>
   </setupTask>
@@ -149,13 +151,6 @@
             rootFolder="${ros-model.location}/plugins/">
           <excludedPath>.</excludedPath>
         </sourceLocator>
-        <repositoryList
-          name="2024-09">
-          <repository
-              url="https://download.eclipse.org/releases/2024-09"/>
-          <repository 
-              url="https://download.eclipse.org/eclipse/updates/4.33"/>
-        </repositoryList>
       </targlet>
       <implicitDependency
           id="org.eclipse.sirius.runtime.ide.ui"/>

--- a/EclipseInstaller/ROSModel.setup
+++ b/EclipseInstaller/ROSModel.setup
@@ -50,7 +50,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="2021-12"
+      defaultValue="2024-09"
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup.p2:P2Task">
@@ -78,9 +78,15 @@
       <requirement
           name="org.eclipse.egit.feature.group"/>
       <repositoryList
-          name="2021-12">
+          name="2024-09">
         <repository
-            url="https://download.eclipse.org/releases/2021-12"/>
+            url="https://download.eclipse.org/releases/2024-09"/>
+        <repository
+            url="https://download.eclipse.org/eclipse/updates/4.33"/>
+        <repository 
+            url="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
+        <repository 
+            url="https://download.eclipse.org/modeling/emft/mwe/updates/releases/"/>
       </repositoryList>
     </targlet>
   </setupTask>
@@ -146,6 +152,25 @@
             rootFolder="${ros-model.location}/plugins/">
           <excludedPath>.</excludedPath>
         </sourceLocator>
+        <repositoryList 
+            name="2024-09">
+          <repository 
+            url="https://download.eclipse.org/releases/2024-09"/>
+          <repository
+            url="https://download.eclipse.org/eclipse/updates/4.33"/>
+          <repository
+            url="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
+          <repository
+            url="https://download.eclipse.org/modeling/emft/mwe/updates/releases/"/>
+        </repositoryList>
+        <repositoryList name="2021-12">
+          <repository
+            url="https://download.eclipse.org/releases/2021-12"/>
+          <repository
+            url="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
+          <repository
+            url="https://download.eclipse.org/modeling/emft/mwe/updates/releases/"/>
+        </repositoryList>
       </targlet>
       <implicitDependency
           id="org.eclipse.sirius.runtime.ide.ui"/>

--- a/EclipseInstaller/ROSModel.setup
+++ b/EclipseInstaller/ROSModel.setup
@@ -62,10 +62,9 @@
         name="org.eclipse.sirius.specifier.feature.group"/>
     <requirement
         name="org.eclipse.cdt.feature.group"/>
-      <requirement
-          name="org.eclipse.sdk.feature.group"/>
-      <requirement
-          name="org.eclipse.m2e.feature.feature.group"/>
+    <requirement name="org.eclipse.platform.ide"/>
+    <requirement
+        name="org.eclipse.m2e.feature.feature.group"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -85,7 +84,6 @@
             url="https://download.eclipse.org/releases/2024-09"/>
         <repository 
             url="https://download.eclipse.org/eclipse/updates/4.33"/>
-        
       </repositoryList>
     </targlet>
   </setupTask>
@@ -151,6 +149,13 @@
             rootFolder="${ros-model.location}/plugins/">
           <excludedPath>.</excludedPath>
         </sourceLocator>
+        <repositoryList
+          name="2024-09">
+          <repository
+              url="https://download.eclipse.org/releases/2024-09"/>
+          <repository 
+              url="https://download.eclipse.org/eclipse/updates/4.33"/>
+        </repositoryList>
       </targlet>
       <implicitDependency
           id="org.eclipse.sirius.runtime.ide.ui"/>

--- a/EclipseInstaller/ROSModel.setup
+++ b/EclipseInstaller/ROSModel.setup
@@ -16,8 +16,8 @@
     label="ROS Model">
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-11"
-      location="${jre.location-1.8}">
+      version="JavaSE-21"
+      location="${jre.location-21}">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -50,10 +50,12 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="2021-12"
+      defaultValue="2024-09"
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup.p2:P2Task">
+    <repository url="https://download.eclipse.org/releases/2024-09"/>
+    <repository url="https://download.eclipse.org/eclipse/updates/4.33"/>
     <requirement
         name="org.eclipse.xtext.sdk.feature.group"/>
     <requirement
@@ -78,9 +80,12 @@
       <requirement
           name="org.eclipse.egit.feature.group"/>
       <repositoryList
-          name="2021-12">
+          name="2024-09">
         <repository
-            url="https://download.eclipse.org/releases/2021-12"/>
+            url="https://download.eclipse.org/releases/2024-09"/>
+        <repository 
+            url="https://download.eclipse.org/eclipse/updates/4.33"/>
+        
       </repositoryList>
     </targlet>
   </setupTask>

--- a/EclipseInstaller/ROSModel.setup
+++ b/EclipseInstaller/ROSModel.setup
@@ -16,8 +16,8 @@
     label="ROS Model">
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-21"
-      location="${jre.location-21}">
+      version="JavaSE-11"
+      location="${jre.location-1.8}">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -50,12 +50,10 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="2024-09"
+      defaultValue="2021-12"
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup.p2:P2Task">
-    <repository url="https://download.eclipse.org/releases/2024-09"/>
-    <repository url="https://download.eclipse.org/eclipse/updates/4.33"/>
     <requirement
         name="org.eclipse.xtext.sdk.feature.group"/>
     <requirement
@@ -80,12 +78,9 @@
       <requirement
           name="org.eclipse.egit.feature.group"/>
       <repositoryList
-          name="2024-09">
+          name="2021-12">
         <repository
-            url="https://download.eclipse.org/releases/2024-09"/>
-        <repository 
-            url="https://download.eclipse.org/eclipse/updates/4.33"/>
-        
+            url="https://download.eclipse.org/releases/2021-12"/>
       </repositoryList>
     </targlet>
   </setupTask>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Technical Maintainer: [**ipa-nhg**](https://github.com/ipa-nhg/) (**Nadia Hammou
 
 The **documentation** of the RosTooling is available under [https://ipa320.github.io/RosTooling.github.io/](https://ipa320.github.io/RosTooling.github.io/).
 
+
+**Note on source installation:** Source installation documentation is slightly outdated. The ROS xtext plugin is built against newer Eclipse platforms than the one stated in the documentation. Please use Eclipse 2024-09 with maven version 3.9.9.
 ---------------------------------------------------------
 
 


### PR DESCRIPTION
Hi @ipa-rwu,

As you probably know, I was struggling with the source install of RosTooling since last week due to version mismatches. To solve this issue, I have made the following changes:

**- ROSModel.setup:**

1. Updated Target platform version to 2024-09
2. Updated the Ros Model setup task `setup.targlets:TargletTask` with new repositories to pull from during installation process.
3. Added same repositories to the ROS modeling setup task `setup.targlets:TargletTask`

I have tested the building and installation of the plugin on my system and it works so far.